### PR TITLE
Prevent over-capacity activity signups

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,13 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Validate activity has space available
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}


### PR DESCRIPTION
## Summary\n- add capacity validation in `POST /activities/{activity_name}/signup`\n- return `400 Activity is full` when the participant limit is reached\n- keep existing duplicate-signup and activity-not-found behavior unchanged\n\n## Bug\nThe signup endpoint accepted registrations even after an activity reached `max_participants`, allowing over-enrollment and negative spots in the UI.\n\n## Validation\n- exercised signup flow directly in Python and confirmed overflow signups are rejected with `400` and `Activity is full`