### PR TITLE
Normalize and validate activity signup emails

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -33,7 +33,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
-| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity                                         |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Remove a student from an activity by their email address            |
 
 ## Data Model
 

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister from activities
+- Automatic email normalization (trim + lowercase) and validation
 
 ## Getting Started
 
@@ -31,6 +33,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity                                         |
 
 ## Data Model
 

--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
-- Unregister from activities
+- Unregister a student from an activity by email
 - Automatic email normalization: trim and lowercase before validation
 
 ## Getting Started

--- a/src/README.md
+++ b/src/README.md
@@ -7,7 +7,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 - View all available extracurricular activities
 - Sign up for activities
 - Unregister from activities
-- Automatic email normalization (trim + lowercase) and validation
+- Automatic email normalization: trim and lowercase before validation
 
 ## Getting Started
 

--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import re
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -78,6 +79,17 @@ activities = {
 }
 
 
+EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def normalize_email(email: str) -> str:
+    """Normalize and validate incoming student email addresses."""
+    normalized = email.strip().lower()
+    if not EMAIL_PATTERN.match(normalized):
+        raise HTTPException(status_code=422, detail="Invalid email format")
+    return normalized
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -91,15 +103,19 @@ def get_activities():
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
+    email = normalize_email(email)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
     # Get the specific activity
     activity = activities[activity_name]
+    participants_normalized = {participant.strip().lower()
+                               for participant in activity["participants"]}
 
     # Validate student is not already signed up
-    if email in activity["participants"]:
+    if email in participants_normalized:
         raise HTTPException(
             status_code=400,
             detail="Student is already signed up"
@@ -120,20 +136,27 @@ def signup_for_activity(activity_name: str, email: str):
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
+    email = normalize_email(email)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
     # Get the specific activity
     activity = activities[activity_name]
+    participant_to_remove = next(
+        (participant for participant in activity["participants"]
+         if participant.strip().lower() == email),
+        None,
+    )
 
     # Validate student is signed up
-    if email not in activity["participants"]:
+    if participant_to_remove is None:
         raise HTTPException(
             status_code=400,
             detail="Student is not signed up for this activity"
         )
 
     # Remove student
-    activity["participants"].remove(email)
+    activity["participants"].remove(participant_to_remove)
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
- normalize incoming signup/unregister emails by trimming whitespace and lowercasing
- validate email format before processing activity enrollment operations
- make duplicate signup and unregister checks case-insensitive
- document unregister endpoint and email handling in src/README.md

## Why
Email casing or trailing spaces could previously create duplicate enrollments or failed unregister operations for the same student identity.